### PR TITLE
force_new_deployment flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "aws_ecs_service" "service" {
   enable_ecs_managed_tags            = var.enable_ecs_managed_tags
   health_check_grace_period_seconds  = var.health_check_grace_period_seconds
   launch_type                        = "FARGATE"
+  force_new_deployment               = var.force_new_deployment
   dynamic "load_balancer" {
     for_each = data.aws_lb_target_group.lb_http_target_groups
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,8 @@ variable "task_definition_arn" {
 
 variable "force_new_deployment"{
   description = "(Optional) Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered_placement_strategy and placement_constraints updates."
+  type = bool
+  default = false
 }
 
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,10 @@ variable "task_definition_arn" {
   description = "(Required) The full ARN of the task definition that you want to run in your service."
 }
 
+variable "force_new_deployment"{
+  description = "(Optional) Enable to force a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform version, or immediately deploy ordered_placement_strategy and placement_constraints updates."
+}
+
 #------------------------------------------------------------------------------
 # AWS ECS SERVICE network_configuration BLOCK
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I have found out that force_new_deployment flag is often needed to redeploy a new revision of each task. This is especially useful when this module is used with CI/CD