### PR TITLE
Add downstream variable block_s3_bucket_public_access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,9 @@ module "ecs-alb" {
   name_prefix = var.name_prefix
   vpc_id      = var.vpc_id
 
+  # S3 Bucket
+  block_s3_bucket_public_access    = var.block_s3_bucket_public_access
+
   # Application Load Balancer
   internal                         = var.lb_internal
   security_groups                  = var.lb_security_groups

--- a/variables.tf
+++ b/variables.tf
@@ -376,3 +376,12 @@ variable "additional_certificates_arn_for_https_listeners" {
   type        = list(any)
   default     = []
 }
+
+#------------------------------------------------------------------------------
+# S3 bucket
+#------------------------------------------------------------------------------
+variable "block_s3_bucket_public_access" {
+  description = "(Optional) If true, public access to the S3 bucket will be blocked."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR allows using the added variable `block_s3_bucket_public_access` in cn-terraform/terraform-aws-ecs-alb#5 to block public access to the S3 bucket that stores the ALB logs.