### PR TITLE
Bump cn-terraform/ecs-alb/aws to 1.0.10

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 module "ecs-alb" {
   source  = "cn-terraform/ecs-alb/aws"
-  version = "1.0.9"
+  version = "1.0.10"
 
   name_prefix = var.name_prefix
   vpc_id      = var.vpc_id


### PR DESCRIPTION
This will enable configuration of the target group protocol.