### PR TITLE
Bump cn-terraform/ecs-alb/aws to 1.0.11

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 module "ecs-alb" {
   source  = "cn-terraform/ecs-alb/aws"
-  version = "1.0.10"
+  version = "1.0.11"
 
   name_prefix = var.name_prefix
   vpc_id      = var.vpc_id


### PR DESCRIPTION
Fix a race condition in the ALB logs bucket fixed in https://github.com/cn-terraform/terraform-aws-ecs-alb/pull/11